### PR TITLE
feat: Add "options" to modify CPU, RAM, disk on existing VM

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -61,6 +61,14 @@ type autoRefreshTickMsg time.Time
 // infoRefreshTickMsg fires periodically to refresh the VM info detail view.
 type infoRefreshTickMsg time.Time
 
+// optionsResultMsg carries the result of loading VM options.
+type optionsResultMsg struct {
+	vmName string
+	config ResourceConfig
+	limits HostLimits
+	err    error
+}
+
 // ─── Auto-Refresh ──────────────────────────────────────────────────────────────
 
 const autoRefreshInterval = 1 * time.Second
@@ -282,5 +290,20 @@ func umountCmd(vmName, target string) tea.Cmd {
 	return func() tea.Msg {
 		_, err := runMultipassCommand("umount", vmName+":"+target)
 		return vmOperationResultMsg{vmName: vmName, operation: "umount", err: err}
+	}
+}
+
+// loadOptionsCmd loads VM resource options.
+func loadOptionsCmd(vmName string) tea.Cmd {
+	return func() tea.Msg {
+		config, err := getVMResourceConfig(vmName)
+		if err != nil {
+			return optionsResultMsg{vmName: vmName, config: ResourceConfig{}, limits: HostLimits{}, err: err}
+		}
+		limits, err := getHostLimits()
+		if err != nil {
+			return optionsResultMsg{vmName: vmName, config: config, limits: HostLimits{}, err: err}
+		}
+		return optionsResultMsg{vmName: vmName, config: config, limits: limits, err: nil}
 	}
 }

--- a/options_operations.go
+++ b/options_operations.go
@@ -1,0 +1,255 @@
+// options_operations.go - VM resource configuration management (data logic, no UI)
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// ResourceConfig holds VM resource settings
+type ResourceConfig struct {
+	CPUs   int
+	Memory string // Format: "8.0GiB"
+	Disk   string // Format: "40.0GiB"
+}
+
+// HostLimits holds maximum resource limits from host
+type HostLimits struct {
+	MaxCPUs   int
+	MaxMemory int // in MB
+}
+
+// parseMemoryToMB converts memory string to MB
+// Supports: "8.0GiB", "8G", "512.0MiB", "512MB", "512M", "512" (assumes MB)
+func parseMemoryToMB(memStr string) (int, error) {
+	memStr = strings.TrimSpace(strings.ToUpper(memStr))
+	if memStr == "" {
+		return 0, fmt.Errorf("memory string is empty")
+	}
+
+	var value float64
+	var unit string
+	var err error
+
+	// Try to parse with different suffixes
+	if strings.HasSuffix(memStr, "GIB") {
+		valueStr := strings.TrimSuffix(memStr, "GIB")
+		value, err = strconv.ParseFloat(valueStr, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid memory value: %s", valueStr)
+		}
+		unit = "G"
+	} else if strings.HasSuffix(memStr, "MIB") {
+		valueStr := strings.TrimSuffix(memStr, "MIB")
+		value, err = strconv.ParseFloat(valueStr, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid memory value: %s", valueStr)
+		}
+		unit = "M"
+	} else if strings.HasSuffix(memStr, "GB") {
+		valueStr := strings.TrimSuffix(memStr, "GB")
+		value, err = strconv.ParseFloat(valueStr, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid memory value: %s", valueStr)
+		}
+		unit = "G"
+	} else if strings.HasSuffix(memStr, "G") {
+		valueStr := strings.TrimSuffix(memStr, "G")
+		value, err = strconv.ParseFloat(valueStr, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid memory value: %s", valueStr)
+		}
+		unit = "G"
+	} else if strings.HasSuffix(memStr, "MB") {
+		valueStr := strings.TrimSuffix(memStr, "MB")
+		value, err = strconv.ParseFloat(valueStr, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid memory value: %s", valueStr)
+		}
+		unit = "M"
+	} else if strings.HasSuffix(memStr, "M") {
+		valueStr := strings.TrimSuffix(memStr, "M")
+		value, err = strconv.ParseFloat(valueStr, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid memory value: %s", valueStr)
+		}
+		unit = "M"
+	} else {
+		// No unit, assume MB
+		value, err = strconv.ParseFloat(memStr, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid memory value: %s", memStr)
+		}
+		unit = "M"
+	}
+
+	// Convert to MB
+	if unit == "G" {
+		return int(value * 1024), nil
+	}
+	return int(value), nil
+}
+
+// formatMemoryToMiB formats MB to MiB format for multipass
+// Preserves exact MB value without precision loss from GiB conversion
+func formatMemoryToMiB(memMB int) string {
+	return fmt.Sprintf("%d.0MiB", memMB)
+}
+
+// parseDiskToGB converts disk string to GB
+// Supports: "40.0GiB", "40G", "40GB", "512.0MiB", "512" (assumes GB if no unit)
+func parseDiskToGB(diskStr string) (int, error) {
+	diskStr = strings.TrimSpace(strings.ToUpper(diskStr))
+	if diskStr == "" {
+		return 0, fmt.Errorf("disk string is empty")
+	}
+
+	var value float64
+	var err error
+
+	// Try to parse with different suffixes
+	if strings.HasSuffix(diskStr, "GIB") {
+		valueStr := strings.TrimSuffix(diskStr, "GIB")
+		value, err = strconv.ParseFloat(valueStr, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid disk value: %s", valueStr)
+		}
+	} else if strings.HasSuffix(diskStr, "MIB") {
+		valueStr := strings.TrimSuffix(diskStr, "MIB")
+		value, err = strconv.ParseFloat(valueStr, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid disk value: %s", valueStr)
+		}
+		value = value / 1024 // Convert MiB to GB
+	} else if strings.HasSuffix(diskStr, "GB") {
+		valueStr := strings.TrimSuffix(diskStr, "GB")
+		value, err = strconv.ParseFloat(valueStr, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid disk value: %s", valueStr)
+		}
+	} else if strings.HasSuffix(diskStr, "G") {
+		valueStr := strings.TrimSuffix(diskStr, "G")
+		value, err = strconv.ParseFloat(valueStr, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid disk value: %s", valueStr)
+		}
+	} else {
+		// No unit, assume GB
+		value, err = strconv.ParseFloat(diskStr, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid disk value: %s", diskStr)
+		}
+	}
+
+	return int(value), nil
+}
+
+// formatDiskToGiB converts GB to GiB format for multipass
+func formatDiskToGiB(diskGB int) string {
+	return fmt.Sprintf("%d.0GiB", diskGB)
+}
+
+// getVMResourceConfig retrieves current resource settings for a VM
+func getVMResourceConfig(vmName string) (ResourceConfig, error) {
+	cpuOut, err := runMultipassCommand("get", fmt.Sprintf("local.%s.cpus", vmName))
+	if err != nil {
+		return ResourceConfig{}, fmt.Errorf("failed to get CPU config: %v", err)
+	}
+
+	memOut, err := runMultipassCommand("get", fmt.Sprintf("local.%s.memory", vmName))
+	if err != nil {
+		return ResourceConfig{}, fmt.Errorf("failed to get memory config: %v", err)
+	}
+
+	diskOut, err := runMultipassCommand("get", fmt.Sprintf("local.%s.disk", vmName))
+	if err != nil {
+		return ResourceConfig{}, fmt.Errorf("failed to get disk config: %v", err)
+	}
+
+	cpus, err := strconv.Atoi(strings.TrimSpace(cpuOut))
+	if err != nil {
+		return ResourceConfig{}, fmt.Errorf("invalid CPU value: %v", err)
+	}
+
+	return ResourceConfig{
+		CPUs:   cpus,
+		Memory: strings.TrimSpace(memOut),
+		Disk:   strings.TrimSpace(diskOut),
+	}, nil
+}
+
+// getHostLimits retrieves maximum resource limits from host
+func getHostLimits() (HostLimits, error) {
+	maxCPUs := runtime.NumCPU()
+
+	// Get total memory using "free -m"
+	output, err := exec.Command("free", "-m").Output()
+	if err != nil {
+		// Fallback to reasonable defaults if free command fails
+		if appLogger != nil {
+			appLogger.Printf("Warning: failed to get memory info: %v, using defaults", err)
+		}
+		return HostLimits{
+			MaxCPUs:   maxCPUs,
+			MaxMemory: 32768, // 32GB fallback
+		}, nil
+	}
+
+	lines := strings.Split(string(output), "\n")
+	if len(lines) < 2 {
+		return HostLimits{}, fmt.Errorf("unexpected free output format")
+	}
+
+	fields := strings.Fields(lines[1])
+	if len(fields) < 2 {
+		return HostLimits{}, fmt.Errorf("unexpected free output fields")
+	}
+
+	totalMemMB, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return HostLimits{}, fmt.Errorf("invalid memory value: %v", err)
+	}
+
+	// Use 75% of total memory as maximum to leave headroom
+	maxMemMB := int(float64(totalMemMB) * 0.75)
+
+	return HostLimits{
+		MaxCPUs:   maxCPUs,
+		MaxMemory: maxMemMB,
+	}, nil
+}
+
+// setVMResourceConfig applies new resource settings to a VM
+func setVMResourceConfig(vmName string, config ResourceConfig) error {
+	if appLogger != nil {
+		appLogger.Printf("Setting resources for %s: CPUs=%d, Memory=%s, Disk=%s",
+			vmName, config.CPUs, config.Memory, config.Disk)
+	}
+
+	// Set CPU
+	_, err := runMultipassCommand("set", fmt.Sprintf("local.%s.cpus=%d", vmName, config.CPUs))
+	if err != nil {
+		return fmt.Errorf("failed to set CPUs: %v", err)
+	}
+
+	// Set Memory
+	_, err = runMultipassCommand("set", fmt.Sprintf("local.%s.memory=%s", vmName, config.Memory))
+	if err != nil {
+		return fmt.Errorf("failed to set memory: %v", err)
+	}
+
+	// Set Disk
+	_, err = runMultipassCommand("set", fmt.Sprintf("local.%s.disk=%s", vmName, config.Disk))
+	if err != nil {
+		return fmt.Errorf("failed to set disk: %v", err)
+	}
+
+	if appLogger != nil {
+		appLogger.Printf("Successfully updated resources for %s", vmName)
+	}
+
+	return nil
+}

--- a/view_modals.go
+++ b/view_modals.go
@@ -42,6 +42,7 @@ func (m helpModel) View() string {
 		{"n", "Create snapshot"},
 		{"m", "Manage snapshots"},
 		{"M", "Manage mounts"},
+		{"o", "VM Options (CPU/RAM/Disk)"},
 		{"v", "Version"},
 		{"1-0", "Switch theme (1-9, 0)"},
 		{"q", "Quit"},

--- a/view_options.go
+++ b/view_options.go
@@ -1,0 +1,384 @@
+// view_options.go - VM Options form for modifying CPU, RAM, and Disk
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type optionsModel struct {
+	vmName        string
+	cpuInput      textinput.Model
+	memInput      textinput.Model
+	diskInput     textinput.Model
+	cursor        int // 0=cpu, 1=mem, 2=disk, 3=save, 4=cancel
+	width         int
+	height        int
+	config        ResourceConfig
+	limits        HostLimits
+	currentDiskGB int    // Track current disk for validation
+	validationErr string // Validation error message to display
+}
+
+func newOptionsModel(vmName string, config ResourceConfig, limits HostLimits, width, height int) optionsModel {
+	// Parse current values
+	currentMemMB, _ := parseMemoryToMB(config.Memory)
+	currentDiskGB, _ := parseDiskToGB(config.Disk)
+
+	cpuInput := textinput.New()
+	cpuInput.SetValue(strconv.Itoa(config.CPUs))
+	cpuInput.Focus()
+	cpuInput.CharLimit = 4
+
+	memInput := textinput.New()
+	memInput.SetValue(strconv.Itoa(currentMemMB))
+	memInput.CharLimit = 8
+
+	diskInput := textinput.New()
+	diskInput.SetValue(strconv.Itoa(currentDiskGB))
+	diskInput.CharLimit = 6
+
+	return optionsModel{
+		vmName:        vmName,
+		cpuInput:      cpuInput,
+		memInput:      memInput,
+		diskInput:     diskInput,
+		cursor:        0,
+		width:         width,
+		height:        height,
+		config:         config,
+		limits:        limits,
+		currentDiskGB:  currentDiskGB,
+	}
+}
+
+func (m optionsModel) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m optionsModel) Update(msg tea.Msg) (optionsModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			return m, func() tea.Msg { return backToTableMsg{} }
+
+		case "tab", "down":
+			m.blurCurrent()
+			m.cursor = (m.cursor + 1) % 5
+			m.focusCurrent()
+			return m, nil
+
+		case "shift+tab", "up":
+			m.blurCurrent()
+			m.cursor = (m.cursor - 1 + 5) % 5
+			m.focusCurrent()
+			return m, nil
+
+		case "left":
+			m2, cmd := m.adjustValue(-1)
+			return m2, cmd
+
+		case "right":
+			m2, cmd := m.adjustValue(1)
+			return m2, cmd
+
+		case "enter":
+			if m.cursor == 4 { // Cancel
+				return m, func() tea.Msg { return backToTableMsg{} }
+			}
+			if m.cursor == 3 { // Save
+				return m.submit()
+			}
+			// Move to next field
+			m.blurCurrent()
+			m.cursor = (m.cursor + 1) % 5
+			m.focusCurrent()
+			return m, nil
+		}
+
+		// Text input for current field
+		if m.cursor >= 0 && m.cursor <= 2 {
+			// Clear validation error when user starts typing
+			m.validationErr = ""
+			var cmd tea.Cmd
+			switch m.cursor {
+			case 0:
+				m.cpuInput, cmd = m.cpuInput.Update(msg)
+			case 1:
+				m.memInput, cmd = m.memInput.Update(msg)
+			case 2:
+				m.diskInput, cmd = m.diskInput.Update(msg)
+			}
+			return m, cmd
+		}
+	}
+
+	// Pass tick messages to focused textinput for cursor blink
+	if m.cursor >= 0 && m.cursor <= 2 {
+		var cmd tea.Cmd
+		switch m.cursor {
+		case 0:
+			m.cpuInput, cmd = m.cpuInput.Update(msg)
+		case 1:
+			m.memInput, cmd = m.memInput.Update(msg)
+		case 2:
+			m.diskInput, cmd = m.diskInput.Update(msg)
+		}
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m *optionsModel) blurCurrent() {
+	switch m.cursor {
+	case 0:
+		m.cpuInput.Blur()
+	case 1:
+		m.memInput.Blur()
+	case 2:
+		m.diskInput.Blur()
+	}
+}
+
+func (m *optionsModel) focusCurrent() {
+	switch m.cursor {
+	case 0:
+		m.cpuInput.Focus()
+	case 1:
+		m.memInput.Focus()
+	case 2:
+		m.diskInput.Focus()
+	}
+}
+
+// adjustValue adjusts the current field value by delta
+func (m *optionsModel) adjustValue(delta int) (optionsModel, tea.Cmd) {
+	switch m.cursor {
+	case 0: // CPU
+		val, err := strconv.Atoi(m.cpuInput.Value())
+		if err == nil {
+			newVal := val + delta
+			if newVal >= MinCPUCores && newVal <= m.limits.MaxCPUs {
+				m.cpuInput.SetValue(strconv.Itoa(newVal))
+			}
+		}
+	case 1: // Memory
+		val, err := strconv.Atoi(m.memInput.Value())
+		if err == nil {
+			newVal := val + (delta * 256) // Adjust by 256MB chunks
+			if newVal >= MinRAMMB && newVal <= m.limits.MaxMemory {
+				m.memInput.SetValue(strconv.Itoa(newVal))
+			}
+		}
+	case 2: // Disk
+		val, err := strconv.Atoi(m.diskInput.Value())
+		if err == nil {
+			newVal := val + delta // Adjust by 1GB chunks
+			if newVal >= m.currentDiskGB && newVal >= MinDiskGB {
+				m.diskInput.SetValue(strconv.Itoa(newVal))
+			}
+		}
+	}
+	return *m, nil
+}
+
+func (m *optionsModel) validate() bool {
+	m.validationErr = ""
+
+	// Validate CPU
+	cpus, err := strconv.Atoi(m.cpuInput.Value())
+	if err != nil || cpus < MinCPUCores {
+		m.validationErr = fmt.Sprintf("CPU must be at least %d", MinCPUCores)
+		return false
+	}
+	if cpus > m.limits.MaxCPUs {
+		m.validationErr = fmt.Sprintf("CPU cannot exceed %d", m.limits.MaxCPUs)
+		return false
+	}
+
+	// Validate Memory
+	memMB, err := strconv.Atoi(m.memInput.Value())
+	if err != nil || memMB < MinRAMMB {
+		m.validationErr = fmt.Sprintf("RAM must be at least %d MB", MinRAMMB)
+		return false
+	}
+	if memMB > m.limits.MaxMemory {
+		m.validationErr = fmt.Sprintf("RAM cannot exceed %d MB", m.limits.MaxMemory)
+		return false
+	}
+
+	// Validate Disk
+	diskGB, err := strconv.Atoi(m.diskInput.Value())
+	if err != nil || diskGB < MinDiskGB {
+		m.validationErr = fmt.Sprintf("Disk must be at least %d GB", MinDiskGB)
+		return false
+	}
+	if diskGB < m.currentDiskGB {
+		m.validationErr = fmt.Sprintf("Disk cannot be smaller than current %d GB", m.currentDiskGB)
+		return false
+	}
+
+	return true
+}
+
+func (m *optionsModel) submit() (optionsModel, tea.Cmd) {
+	// Validate first
+	if !m.validate() {
+		// Return the model with error displayed
+		return *m, nil
+	}
+
+	cpus, _ := strconv.Atoi(m.cpuInput.Value())
+	memMB, _ := strconv.Atoi(m.memInput.Value())
+	diskGB, _ := strconv.Atoi(m.diskInput.Value())
+	vmName := m.vmName
+
+	newConfig := ResourceConfig{
+		CPUs:   cpus,
+		Memory: formatMemoryToMiB(memMB),
+		Disk:   formatDiskToGiB(diskGB),
+	}
+
+	return *m, func() tea.Msg {
+		err := setVMResourceConfig(vmName, newConfig)
+		return vmOperationResultMsg{vmName: vmName, operation: "set-options", err: err}
+	}
+}
+
+func (m optionsModel) View() string {
+	// Title
+	titleLabel := " ◆ VM Options: " + m.vmName
+	w := min(m.width-4, 60)
+	if w < 30 {
+		w = 30
+	}
+	titleText := titleBarStyle.Render(titleLabel)
+	titleVisibleWidth := lipgloss.Width(titleText)
+	if w > titleVisibleWidth {
+		pad := strings.Repeat(" ", w-titleVisibleWidth)
+		titleText += lipgloss.NewStyle().Background(accent).Render(pad)
+	}
+
+	// Column widths
+	labelW := 14
+	valueW := w - labelW - 5
+	if valueW < 16 {
+		valueW = 16
+	}
+
+	divStyle := lipgloss.NewStyle().Foreground(dimmed)
+	div := divStyle.Render("│")
+
+	// Header
+	headerLabel := tableHeaderStyle.Width(labelW).Render("Field")
+	headerValue := tableHeaderStyle.Width(valueW).Render("Value")
+	header := "  " + headerLabel + div + headerValue
+
+	// Separator
+	sep := "  " + divStyle.Render(strings.Repeat("─", labelW)) +
+		divStyle.Render("┼") +
+		divStyle.Render(strings.Repeat("─", valueW))
+
+	// Rows
+	var rows []string
+	var buttons []string
+
+	// CPU row
+	cpuActive := m.cursor == 0
+	cpuPrefix := "  "
+	if cpuActive {
+		cpuPrefix = tableCursorStyle.Render("▎ ")
+	}
+	cpuLabelStyle := formLabelStyle.Width(labelW)
+	if cpuActive {
+		cpuLabelStyle = formActiveLabelStyle.Width(labelW)
+	}
+	cpuLabel := cpuLabelStyle.Render("CPU Cores")
+	cpuVal := m.renderNumericField(m.cpuInput, cpuActive, m.limits.MaxCPUs)
+
+	// Memory row
+	memActive := m.cursor == 1
+	memPrefix := "  "
+	if memActive {
+		memPrefix = tableCursorStyle.Render("▎ ")
+	}
+	memLabelStyle := formLabelStyle.Width(labelW)
+	if memActive {
+		memLabelStyle = formActiveLabelStyle.Width(labelW)
+	}
+	memLabel := memLabelStyle.Render("RAM (MB)")
+	memVal := m.renderNumericField(m.memInput, memActive, m.limits.MaxMemory)
+
+	// Disk row
+	diskActive := m.cursor == 2
+	diskPrefix := "  "
+	if diskActive {
+		diskPrefix = tableCursorStyle.Render("▎ ")
+	}
+	diskLabelStyle := formLabelStyle.Width(labelW)
+	if diskActive {
+		diskLabelStyle = formActiveLabelStyle.Width(labelW)
+	}
+	diskLabel := diskLabelStyle.Render("Disk (GB)")
+	diskVal := m.renderNumericField(m.diskInput, diskActive, 0) // Disk has different validation
+
+	rows = append(rows, cpuPrefix+cpuLabel+div+cpuVal)
+	rows = append(rows, memPrefix+memLabel+div+memVal)
+	rows = append(rows, diskPrefix+diskLabel+div+diskVal)
+
+	// Buttons
+	saveActive := m.cursor == 3
+	cancelActive := m.cursor == 4
+	saveStyle := formButtonStyle
+	cancelStyle := formButtonStyle
+	if saveActive {
+		saveStyle = formActiveButtonStyle
+	}
+	if cancelActive {
+		cancelStyle = formActiveButtonStyle
+	}
+	buttons = append(buttons, saveStyle.Render("[ Save ]"))
+	buttons = append(buttons, cancelStyle.Render("[ Cancel ]"))
+
+	// Build table inside a border box
+	tableContent := header + "\n" + sep + "\n" + strings.Join(rows, "\n")
+	tableBox := tableBorderStyle.Width(w + 2).Render(tableContent)
+
+	// Details panel
+	maxMemGB := m.limits.MaxMemory / 1024
+	detailsText := fmt.Sprintf("Host Limits: Max %d CPUs, Max %d MB (~%d GB)\n\nNote: Disk size cannot be smaller than current allocation.",
+		m.limits.MaxCPUs, m.limits.MaxMemory, maxMemGB)
+	detailsBox := detailPanelStyle.Render(detailsText)
+
+	// Validation error (if any)
+	var errorBox string
+	if m.validationErr != "" {
+		errorBox = "\n" + errorTitleStyle.Render("⚠ "+m.validationErr) + "\n"
+	}
+
+	// Buttons row
+	buttonRow := "  " + strings.Join(buttons, "  ")
+
+	// Hints
+	hint := formHintStyle.Render("  Tab/↑↓: navigate  ←→: adjust values  Enter: save  Esc: cancel")
+
+	content := titleText + "\n" + tableBox + "\n" + detailsBox + errorBox + "\n" + buttonRow + "\n\n" + hint
+
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+}
+
+func (m optionsModel) renderNumericField(input textinput.Model, active bool, maxVal int) string {
+	if active {
+		left := lipgloss.NewStyle().Foreground(accent).Render("◀ ")
+		right := lipgloss.NewStyle().Foreground(accent).Render(" ▶")
+		return left + input.View() + right
+	}
+	return "  " + lipgloss.NewStyle().Foreground(subtle).Render(input.Value()) + "  "
+}

--- a/view_table.go
+++ b/view_table.go
@@ -968,7 +968,7 @@ func (m tableModel) renderFooter() string {
 		{"<", "StopAll"}, {">", "StartAll"}, {"!", "Purge"},
 	}
 	navOps := []struct{ key, desc string }{
-		{"i", "Info"}, {"s", "Shell"}, {"n", "Snap"}, {"m", "Snaps"}, {"M", "Mount"},
+		{"i", "Info"}, {"s", "Shell"}, {"n", "Snap"}, {"m", "Snaps"}, {"M", "Mount"}, {"o", "Options"},
 	}
 	appOps := []struct{ key, desc string }{
 		{"f", "Filter"}, {"/", "Refresh"}, {"1-0", "Theme"}, {"h", "Help"}, {"q", "Quit"},


### PR DESCRIPTION
Add a shortcut key 'o' to enter Options menu of an existing VM to modify its CPU cores, RAM and disk usage.

Max values are based on host limits and disk size change cannot be smaller than existing value.

<img width="645" height="212" alt="image" src="https://github.com/user-attachments/assets/95ab3349-e0bf-4ef6-b1b9-47fa91ff52a3" />
<img width="779" height="444" alt="image" src="https://github.com/user-attachments/assets/44f7008c-0203-46ce-abbd-dd5ce66594fa" />